### PR TITLE
Make ExBook non-destructive

### DIFF
--- a/lib/ex_book.ex
+++ b/lib/ex_book.ex
@@ -4,8 +4,8 @@ defmodule ExBook do
   A tool to generate livebook documentation for your Elixir Projects.
   """
 
-  @exbook_start_marker "--- ExBook ---"
-  @exbook_end_marker "---- ExBook ----"
+  @exbook_start_marker "## ExBook"
+  @exbook_end_marker "`ExBook_end`"
 
   @doc """
   Generate livebook docs for an Elixir app.
@@ -28,43 +28,6 @@ defmodule ExBook do
     |> get_modules(ignored)
     |> create_or_edit_file(base_path, opts)
     |> create_index(app, base_path)
-  end
-
-  defp create_or_edit_file(module_tuples, base_path, opts) do
-    Enum.each(module_tuples, fn {module, path} ->
-      path = Path.join(base_path, path)
-      File.mkdir_p!(Path.dirname(path))
-
-      case File.exists?(path) do
-        false ->
-          File.write(path, module_to_livemd(module, opts))
-
-        true ->
-          docs = module_to_livemd(module, opts)
-          stream = File.stream!(path)
-          ex_doc_start = Enum.find_index(stream, &(&1 == @exbook_start_marker))
-          ex_doc_end = Enum.find_index(stream, &(&1 == @exbook_end_marker))
-
-          case {ex_doc_start, ex_doc_end} do
-            {nil, nil} ->
-              docs
-
-            # TODO
-            {doc_start, nil} ->
-              :noop
-
-            # TODO
-            {nil, doc_end} ->
-              :noop
-
-            {doc_start, doc_end} ->
-              # TODO add end of doc
-              Enum.slice(stream, 0..doc_start) <> docs
-          end
-      end
-    end)
-
-    module_tuples
   end
 
   def module_to_livemd(module, opts \\ []) do
@@ -105,29 +68,18 @@ defmodule ExBook do
 
     setup = if deps, do: "```elixir\nMix.install(#{inspect(deps)})\n```", else: ""
 
+    # LiveBook is smart enough to percolate the `module_name` to the top of the file
+    # However utilizing this in place of our own logic is not wise and should be resolved
     """
+    #{@exbook_start_marker}
     # #{module_name}
     #{setup}
-    #{@exbook_start_marker}
     ## Module Doc
     #{module_doc}
     ## Functions
     #{functions}
     #{@exbook_end_marker}
     """
-  end
-
-  defp create_index(module_tuples, app, base_path) do
-    app_name = build_app_name(app)
-    module_links = build_module_links(module_tuples)
-
-    Path.join(base_path, "index.livemd")
-    |> File.write!("""
-    # #{app_name}
-
-    ## Modules
-    #{module_links}
-    """)
   end
 
   defp build_app_name(app) do
@@ -144,6 +96,64 @@ defmodule ExBook do
       "- [#{module_name}](./#{path})"
     end)
     |> Enum.join("\n")
+  end
+
+  defp create_index(module_tuples, app, base_path) do
+    app_name = build_app_name(app)
+    module_links = build_module_links(module_tuples)
+
+    Path.join(base_path, "index.livemd")
+    |> File.write!("""
+    # #{app_name}
+
+    ## Modules
+    #{module_links}
+    """)
+  end
+
+  defp create_or_edit_file(module_tuples, base_path, opts) do
+    Enum.each(module_tuples, fn {module, path} ->
+      path = Path.join(base_path, path)
+      File.mkdir_p!(Path.dirname(path))
+
+      case File.exists?(path) do
+        false ->
+          File.write(path, module_to_livemd(module, opts))
+
+        true ->
+          docs = module_to_livemd(module, opts)
+          stream = File.stream!(path)
+          ex_doc_start = Enum.find_index(stream, &(&1 == "#{@exbook_start_marker}\n"))
+          ex_doc_end = Enum.find_index(stream, &(&1 == "#{@exbook_end_marker}\n"))
+
+          {:ok, updated_docs} =
+            case {ex_doc_start, ex_doc_end} do
+              {nil, nil} ->
+                # a decision has to be made here, putting it at the end may not be ideal
+                # however it's the least disruptive decision
+                {:ok, Enum.slice(stream, 0..-1) ++ [docs]}
+
+              # Failing hard in the error cases is acceptable for now,
+              # However a graceful return with more meaningful info is preferred
+              {_ex_doc_start, nil} ->
+                {:error, :corrupted_file}
+
+              {nil, _ex_doc_end} ->
+                {:error, :corrupted_file}
+
+              {ex_doc_start, ex_doc_end} ->
+                ex_doc_start = ex_doc_start - 1
+                ex_doc_end = ex_doc_end + 1
+                {:ok,
+                 Enum.slice(stream, 0..ex_doc_start) ++
+                   [docs] ++ Enum.slice(stream, ex_doc_end..-1)}
+            end
+
+          Stream.into(updated_docs, stream) |> Stream.run()
+      end
+    end)
+
+    module_tuples
   end
 
   defp get_modules(app, ignored) do

--- a/test/ex_book_test.exs
+++ b/test/ex_book_test.exs
@@ -40,6 +40,43 @@ defmodule ExBookTest do
     # File.rm_rf("test_notebooks")
   end
 
+  test "app_to_exbook/1 only changes the appropriate tags in the livemd" do
+    #TODO
+    File.rm_rf("test_notebooks")
+
+    ExBook.app_to_exbook(:ex_book,
+      path: @app_path,
+      ignore: [ExBook, Mix.Tasks.Notebooks],
+      deps: [{:kino, "~> 0.6.2"}, {:ex_doc, path: "./"}]
+    )
+    setup = "```elixir\nMix.install([kino: \"~> 0.6.2\", ex_doc: [path: \"./\"]])\n```"
+
+    assert File.read!(@app_path <> "ExampleModule.livemd") == example_doc("ExampleModule", setup)
+
+    assert File.read!(@app_path <> "ExampleModule/SubExample1.livemd") ==
+             example_doc("ExampleModule.SubExample1", setup)
+
+    assert File.read!(@app_path <> "ExampleModule/SubExample2.livemd") ==
+             example_doc("ExampleModule.SubExample2", setup)
+
+    assert File.read!(@app_path <> "ExampleModule/SubExample3.livemd") ==
+             example_doc("ExampleModule.SubExample3", setup)
+
+    refute File.exists?(@app_path <> "ExBook.livemd")
+
+    assert File.read!(@app_path <> "index.livemd") == """
+           # ExBook
+
+           ## Modules
+           - [ExampleModule](./ExampleModule.livemd)
+           - [ExampleModule.SubExample1](./ExampleModule/SubExample1.livemd)
+           - [ExampleModule.SubExample2](./ExampleModule/SubExample2.livemd)
+           - [ExampleModule.SubExample3](./ExampleModule/SubExample3.livemd)
+           """
+
+    File.rm_rf("test_notebooks")
+  end
+
   test "module to livemd/1" do
     assert ExBook.module_to_livemd(ExampleModule) == example_doc()
   end

--- a/test/ex_book_test.exs
+++ b/test/ex_book_test.exs
@@ -3,6 +3,8 @@ defmodule ExBookTest do
   doctest ExBook
 
   @app_path "./test_notebooks/"
+  @doc_start "## ExBook"
+  @doc_end "`ExBook_end`"
 
   test "app_to_exbook/1 generate project livebooks" do
     File.rm_rf("test_notebooks")
@@ -12,6 +14,7 @@ defmodule ExBookTest do
       ignore: [ExBook, Mix.Tasks.Notebooks],
       deps: [{:kino, "~> 0.6.2"}, {:ex_doc, path: "./"}]
     )
+
     setup = "```elixir\nMix.install([kino: \"~> 0.6.2\", ex_doc: [path: \"./\"]])\n```"
 
     assert File.read!(@app_path <> "ExampleModule.livemd") == example_doc("ExampleModule", setup)
@@ -37,42 +40,121 @@ defmodule ExBookTest do
            - [ExampleModule.SubExample3](./ExampleModule/SubExample3.livemd)
            """
 
-    # File.rm_rf("test_notebooks")
+    File.rm_rf("test_notebooks")
   end
 
-  test "app_to_exbook/1 only changes the appropriate tags in the livemd" do
-    #TODO
+  test "app_to_exbook/1 only makes changes within ExBook tags in the file" do
     File.rm_rf("test_notebooks")
+
+    updated_doc = """
+    ### Do not delete
+    #{@doc_start}
+    # ExampleModule
+    ```elixir
+    Mix.install([])
+    ```
+    ## Module Doc
+    Documentation for `ExampleModule`
+
+    ## Functions
+    ### hello/0
+
+    Example Function
+
+    #### Examples
+
+    ```elixir
+    ExampleModule.hello()
+    ```
+
+    #{@doc_end}
+    ### Do not delete
+    """
+
+    File.mkdir_p!(@app_path)
+
+    File.write!(@app_path <> "ExampleModule.livemd", """
+    ### Do not delete
+    #{@doc_start}
+    #{@doc_end}
+    ### Do not delete
+    """)
 
     ExBook.app_to_exbook(:ex_book,
       path: @app_path,
       ignore: [ExBook, Mix.Tasks.Notebooks],
-      deps: [{:kino, "~> 0.6.2"}, {:ex_doc, path: "./"}]
+      deps: []
     )
-    setup = "```elixir\nMix.install([kino: \"~> 0.6.2\", ex_doc: [path: \"./\"]])\n```"
 
-    assert File.read!(@app_path <> "ExampleModule.livemd") == example_doc("ExampleModule", setup)
+    assert File.read!(@app_path <> "ExampleModule.livemd") == updated_doc
 
-    assert File.read!(@app_path <> "ExampleModule/SubExample1.livemd") ==
-             example_doc("ExampleModule.SubExample1", setup)
+    File.rm_rf("test_notebooks")
+  end
 
-    assert File.read!(@app_path <> "ExampleModule/SubExample2.livemd") ==
-             example_doc("ExampleModule.SubExample2", setup)
+  test "app_to_exbook/1 appends when file exists but doesn't have exbook" do
+    File.rm_rf("test_notebooks")
 
-    assert File.read!(@app_path <> "ExampleModule/SubExample3.livemd") ==
-             example_doc("ExampleModule.SubExample3", setup)
+    updated_doc = """
+    ### Do not delete
+    #{@doc_start}
+    # ExampleModule
+    ```elixir
+    Mix.install([])
+    ```
+    ## Module Doc
+    Documentation for `ExampleModule`
 
-    refute File.exists?(@app_path <> "ExBook.livemd")
+    ## Functions
+    ### hello/0
 
-    assert File.read!(@app_path <> "index.livemd") == """
-           # ExBook
+    Example Function
 
-           ## Modules
-           - [ExampleModule](./ExampleModule.livemd)
-           - [ExampleModule.SubExample1](./ExampleModule/SubExample1.livemd)
-           - [ExampleModule.SubExample2](./ExampleModule/SubExample2.livemd)
-           - [ExampleModule.SubExample3](./ExampleModule/SubExample3.livemd)
-           """
+    #### Examples
+
+    ```elixir
+    ExampleModule.hello()
+    ```
+
+    #{@doc_end}
+    """
+
+    File.mkdir_p!(@app_path)
+
+    File.write!(@app_path <> "ExampleModule.livemd", """
+    ### Do not delete
+    """)
+
+    ExBook.app_to_exbook(:ex_book,
+      path: @app_path,
+      ignore: [ExBook, Mix.Tasks.Notebooks],
+      deps: []
+    )
+
+    assert File.read!(@app_path <> "ExampleModule.livemd") == updated_doc
+
+    File.rm_rf("test_notebooks")
+  end
+
+  test "app_to_exbook/1 fails when ExBook markers corrupted" do
+    File.rm_rf("test_notebooks")
+
+    File.mkdir_p!(@app_path)
+
+    File.write!(@app_path <> "ExampleModule.livemd", """
+    ### This once had ExBook
+
+    however something happened to the tags
+    #{@doc_start}
+
+    """)
+
+    assert_raise MatchError, fn ->
+      ExBook.app_to_exbook(:ex_book,
+        path: @app_path,
+        ignore: [ExBook, Mix.Tasks.Notebooks],
+        deps: []
+      )
+    end
 
     File.rm_rf("test_notebooks")
   end
@@ -89,6 +171,7 @@ defmodule ExBookTest do
 
   defp example_doc(module_name \\ "ExampleModule", setup \\ "") do
     """
+    #{@doc_start}
     # #{module_name}
     #{setup}
     ## Module Doc
@@ -105,6 +188,7 @@ defmodule ExBookTest do
     ExampleModule.hello()
     ```
 
+    #{@doc_end}
     """
   end
 end


### PR DESCRIPTION
When ExBook finds a file it wants to write to, that exists it evaluates:
- Is there an ExBook section (using ExBook section and end marker)
  - yes: only overwrite that section
  - partially true: raise
  - no: insert ExBook section