### PR TITLE
display properly multiple examples (doctests) for a function

### DIFF
--- a/lib/ex_book.ex
+++ b/lib/ex_book.ex
@@ -52,7 +52,7 @@ defmodule ExBook do
         {{:function, fn_name, arity}, _line_number, _usage, %{"en" => doc_string}, _empty_map} ->
           examples =
             doc_string
-            |> String.replace(~r/iex\> (.*)(.|\n)+?(?=(iex|$))/, "```elixir\n\\1\n```")
+            |> String.replace(~r/iex\> (.*)(.|\n)+?(?=(iex|$))/, "```elixir\n\\1\n```\n")
             |> String.replace("##", "####")
             |> String.replace(~r/ {2,}/, "")
 
@@ -144,6 +144,7 @@ defmodule ExBook do
               {ex_doc_start, ex_doc_end} ->
                 ex_doc_start = ex_doc_start - 1
                 ex_doc_end = ex_doc_end + 1
+
                 {:ok,
                  Enum.slice(stream, 0..ex_doc_start) ++
                    [docs] ++ Enum.slice(stream, ex_doc_end..-1)}

--- a/lib/example_module.ex
+++ b/lib/example_module.ex
@@ -14,4 +14,22 @@ defmodule ExampleModule do
   def hello() do
     :hello
   end
+
+  @doc """
+  Block to test handling multiple doctests
+
+    ## Examples
+
+      iex> ExampleModule.parrot("goose")
+      "goose"
+
+      iex> ExampleModule.parrot("parrot")
+      "I'm Cicil"
+  """
+  def parrot(speak) do
+    case speak do
+      "parrot" -> "I'm Cicil"
+      speak -> speak
+    end
+  end
 end

--- a/lib/example_module/sub_example1.ex
+++ b/lib/example_module/sub_example1.ex
@@ -14,4 +14,22 @@ defmodule ExampleModule.SubExample1 do
   def hello() do
     :hello
   end
+
+  @doc """
+  Block to test handling multiple doctests
+
+    ## Examples
+
+      iex> ExampleModule.parrot("goose")
+      "goose"
+
+      iex> ExampleModule.parrot("parrot")
+      "I'm Cicil"
+  """
+  def parrot(speak) do
+    case speak do
+      "parrot" -> "I'm Cicil"
+      speak -> speak
+    end
+  end
 end

--- a/lib/example_module/sub_example2.ex
+++ b/lib/example_module/sub_example2.ex
@@ -14,4 +14,22 @@ defmodule ExampleModule.SubExample2 do
   def hello() do
     :hello
   end
+
+  @doc """
+  Block to test handling multiple doctests
+
+    ## Examples
+
+      iex> ExampleModule.parrot("goose")
+      "goose"
+
+      iex> ExampleModule.parrot("parrot")
+      "I'm Cicil"
+  """
+  def parrot(speak) do
+    case speak do
+      "parrot" -> "I'm Cicil"
+      speak -> speak
+    end
+  end
 end

--- a/lib/example_module/sub_example3.ex
+++ b/lib/example_module/sub_example3.ex
@@ -14,4 +14,22 @@ defmodule ExampleModule.SubExample3 do
   def hello() do
     :hello
   end
+
+  @doc """
+  Block to test handling multiple doctests
+
+    ## Examples
+
+      iex> ExampleModule.parrot("goose")
+      "goose"
+
+      iex> ExampleModule.parrot("parrot")
+      "I'm Cicil"
+  """
+  def parrot(speak) do
+    case speak do
+      "parrot" -> "I'm Cicil"
+      speak -> speak
+    end
+  end
 end

--- a/notebooks/ex_book.livemd
+++ b/notebooks/ex_book.livemd
@@ -99,3 +99,19 @@ Example Function
 ```elixir
 ExampleModule.hello()
 ```
+
+<!-- livebook:{"break_markdown":true} -->
+
+`#ExBook_start`
+
+<!-- livebook:{"force_markdown":true} -->
+
+```elixir
+#Exbook_start
+```
+
+---ExBook---
+
+--- ExBook ---
+
+---- ExBook ----

--- a/test/ex_book_test.exs
+++ b/test/ex_book_test.exs
@@ -46,31 +46,6 @@ defmodule ExBookTest do
   test "app_to_exbook/1 only makes changes within ExBook tags in the file" do
     File.rm_rf("test_notebooks")
 
-    updated_doc = """
-    ### Do not delete
-    #{@doc_start}
-    # ExampleModule
-    ```elixir
-    Mix.install([])
-    ```
-    ## Module Doc
-    Documentation for `ExampleModule`
-
-    ## Functions
-    ### hello/0
-
-    Example Function
-
-    #### Examples
-
-    ```elixir
-    ExampleModule.hello()
-    ```
-
-    #{@doc_end}
-    ### Do not delete
-    """
-
     File.mkdir_p!(@app_path)
 
     File.write!(@app_path <> "ExampleModule.livemd", """
@@ -86,7 +61,13 @@ defmodule ExBookTest do
       deps: []
     )
 
-    assert File.read!(@app_path <> "ExampleModule.livemd") == updated_doc
+    assert File.read!(@app_path <> "ExampleModule.livemd") != ExBook.module_to_livemd(ExampleModule)
+
+    stream = File.stream!(@app_path <> "ExampleModule.livemd")
+
+    assert Enum.at(stream, 0) == "### Do not delete\n"
+    assert Enum.at(stream, -1) == "### Do not delete\n"
+    assert Enum.at(stream, 2) == "# ExampleModule\n"
 
     File.rm_rf("test_notebooks")
   end
@@ -94,30 +75,6 @@ defmodule ExBookTest do
   test "app_to_exbook/1 appends when file exists but doesn't have exbook" do
     File.rm_rf("test_notebooks")
 
-    updated_doc = """
-    ### Do not delete
-    #{@doc_start}
-    # ExampleModule
-    ```elixir
-    Mix.install([])
-    ```
-    ## Module Doc
-    Documentation for `ExampleModule`
-
-    ## Functions
-    ### hello/0
-
-    Example Function
-
-    #### Examples
-
-    ```elixir
-    ExampleModule.hello()
-    ```
-
-    #{@doc_end}
-    """
-
     File.mkdir_p!(@app_path)
 
     File.write!(@app_path <> "ExampleModule.livemd", """
@@ -130,7 +87,12 @@ defmodule ExBookTest do
       deps: []
     )
 
-    assert File.read!(@app_path <> "ExampleModule.livemd") == updated_doc
+    assert File.read!(@app_path <> "ExampleModule.livemd") != ExBook.module_to_livemd(ExampleModule)
+
+    stream = File.stream!(@app_path <> "ExampleModule.livemd")
+
+    assert Enum.at(stream, 0) == "### Do not delete\n"
+    assert Enum.at(stream, -1) == "#{@doc_end}\n"
 
     File.rm_rf("test_notebooks")
   end
@@ -171,7 +133,7 @@ defmodule ExBookTest do
 
   defp example_doc(module_name \\ "ExampleModule", setup \\ "") do
     """
-    #{@doc_start}
+    ## ExBook
     # #{module_name}
     #{setup}
     ## Module Doc
@@ -187,6 +149,20 @@ defmodule ExBookTest do
     ```elixir
     ExampleModule.hello()
     ```
+
+    ### parrot/1
+
+    Block to test handling multiple doctests
+
+    #### Examples
+
+    ```elixir
+    ExampleModule.parrot(\"goose\")
+    ```
+    ```elixir
+    ExampleModule.parrot(\"parrot\")
+    ```
+
 
     #{@doc_end}
     """


### PR DESCRIPTION
Adds a newline when generating the doctest codeblock so that it works as expected when multiple doctests exist for a function.